### PR TITLE
Use `strong` rather than `b` tag for `**`.

### DIFF
--- a/src/markdown/transformers.clj
+++ b/src/markdown/transformers.clj
@@ -95,7 +95,7 @@
         
 
 (defn bold [text state]
-  (separator false text "<b>" "</b>" [\* \*] state))
+  (separator false text "<strong>" "</strong>" [\* \*] state))
 
 (defn alt-bold [text state]
   (separator false text "<b>" "</b>" [\_ \_] state))


### PR DESCRIPTION
With this change:
**foo** -> <strong>foo</strong>
_foo_   -> <em>foo</em>

**foo** -> <b>foo</b>
_foo_   -> <i>foo</i>

The former two carrying semantic meaning, the latter two only stylistic.
