### PR TITLE
Add support for additional escape characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,21 @@ a string followed by the options as its input, and returns the resulting HTML st
 
 Control characters can be escaped using \
 ```
-\*
-\`
-\_
-\(
-\)
-\[
-\]
-\{
+\\ backslash
+\` backtick
+\* asterisk
+\_ underscore
+\{ curly braces
 \}
+\[ square brackets
+\]
+\( parentheses
+\)
+\# hash mark
+\+ plus sign
+\- minus sign (hyphen)
+\. dot
+\! exclamation mark
 ```
 
 #### Basic Elements

--- a/src/markdown/transformers.clj
+++ b/src/markdown/transformers.clj
@@ -48,15 +48,21 @@
   [(if (or (:code state) (:codeblock state))
      text
      (-> text
-       (string/replace #"\\`" "&#8216;")       
-       (string/replace #"\\\*" "&#42;")       
-       (string/replace #"\\_" "&#95;")
+       (string/replace #"\\\\" "&#92;")
+       (string/replace #"\\`"  "&#8216;")
+       (string/replace #"\\\*" "&#42;")
+       (string/replace #"\\_"  "&#95;")
        (string/replace #"\\\{" "&#123;")
        (string/replace #"\\\}" "&#125;")
        (string/replace #"\\\[" "&#91;")
        (string/replace #"\\\]" "&#93;")
        (string/replace #"\\\(" "&#40;")
-       (string/replace #"\\\)" "&#41;")))
+       (string/replace #"\\\)" "&#41;")
+       (string/replace #"\\#"  "&#35;")
+       (string/replace #"\\\+" "&#43;")
+       (string/replace #"\\-"  "&#45;")
+       (string/replace #"\\\." "&#46;")
+       (string/replace #"\\!"  "&#33;")))
    state])
 
 (defn separator [escape? text open close separator state]


### PR DESCRIPTION
Hi Dmitri,

Small change here to add support for the additional prescribed escape characters as per http://daringfireball.net/projects/markdown/syntax#backslash.

Unit tests passing.

Actually while it does get the job done, I think the current control character escaping is technically wrong. As currently implemented, (md-to-html-string "\_") gives "<p>&#42;</p>" where I believe the spec's intention is actually just to give "<p>_</p>". It's not a serious problem. I'm assuming you did this intentionally as an easy way of implementing the control character escaping?

One idea: maybe we could run the process back again after the markdown transforms to replace the &#; encoded forms with their original characters? That way you could keep the same [simple] implementation, if that was a goal. As I said, nothing urgent - just thinking out-loud.

Thanks a lot, cheers! :-)
