### PR TITLE
br transform: remove extra space at eol

### DIFF
--- a/src/markdown/transformers.clj
+++ b/src/markdown/transformers.clj
@@ -175,7 +175,7 @@
 (defn br [text {:keys [code lists] :as state}]
   [(if (and (= [\space \space] (take-last 2 text))
             (not (or code lists)))
-     (str text "<br />")
+     (str (apply str (drop-last 2 text)) "<br />")
      text)
    state])
 

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -16,7 +16,7 @@
         (markdown/md-to-html-string "###foo bar BAz\nsome text" :heading-anchors true))))
 
 (deftest br
-  (is (= "<p>foo  <br /></p>" (markdown/md-to-html-string "foo  ")))
+  (is (= "<p>foo<br /></p>" (markdown/md-to-html-string "foo  ")))
   (is (= "<pre>\nfoo  \n</pre>bar" (markdown/md-to-html-string "```\nfoo  \nbar```"))))
 
 (deftest hr


### PR DESCRIPTION
Hi Dmitri, sorry for submitting these one at a time - am submitting as I notice them.

This fixes a subtle problem with the `br` transform:

``` clojure
(md-to-htm-string "foo  \nbar") => "foo  <br />\n bar" ; Old behaviour
(md-to-htm-string "foo  \nbar") => "foo<br />\n bar"   ; New behaviour
```

The old behaviour can be a problem with center text alignment, etc.

Note that this change required **modifying one unit test**.

There's two additional improvements we could make, but that are less important:
1. `"foo<br>\nbar"` output (no leading space on the 2nd line) would be preferable though isn't practically a problem since afaik all browsers will ignore a leading space following the `<br>` tag. Not sure if there'd be any easy way of doing this?
2. The `br` transform should only actually apply when there's 2 spaces _preceding a newline_. Currently (as in the unit test) it applies even on a single line. Also not a big issue in practice, but it would be nice if we could fix that. Any ideas?

Cheers :-)
