### PR TITLE
Close lists in reverse order

### DIFF
--- a/src/markdown/transformers.clj
+++ b/src/markdown/transformers.clj
@@ -389,12 +389,12 @@
   (cond
 
     (and last-line-empty? (string/blank? text))
-    [(str (close-lists lists) text)
+    [(str (close-lists (reverse lists)) text)
      (-> state (dissoc :lists) (assoc :last-line-empty? false))]
 
     (or code codeblock)
     (if (and lists (or last-line-empty? eof))
-      [(str (close-lists lists) text)
+      [(str (close-lists (reverse lists)) text)
        (-> state (dissoc :lists) (assoc :last-line-empty? false))]
       [text state])
 
@@ -419,7 +419,7 @@
 
         (and (or eof last-line-empty?)
              (not-empty lists))
-        [(close-lists lists)
+        [(close-lists (reverse lists))
          (assoc state :lists [] :buf text)]
 
         :else

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -88,7 +88,9 @@
 
 (deftest ol-in-ul
   (is (= "<ul><li>Foo<ol><li>Bar<ol><li>Subbar</li></ol></li></ol></li><li>Baz</li></ul>"
-         (markdown/md-to-html-string "* Foo\n 1. Bar\n  1. Subbar\n* Baz"))))
+         (markdown/md-to-html-string "* Foo\n 1. Bar\n  1. Subbar\n* Baz")))
+  (is (= "<ul><li>Foo<ol><li>Bar</li></ol></li></ul>"
+         (markdown/md-to-html-string "* Foo\n 1. Bar"))))
 
 (deftest multilist
   (is (=


### PR DESCRIPTION
The following simple nested lists were being closed in the wrong order:

```
* Foo
 1. Bar
```

Added a test case for it. Made it pass by always calling `close-lists` with the lists reversed. This was already being done in one case but not in three others.
