### PR TITLE
Enhance blockquotes to support footers for author attribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,18 @@ __foo__
 ```
 
 ### Blockquote
+`>` prefixes regular blockquote paragraphs.  `>-` prefixes a
+blockquote footer that can be used for author attribution.
+
 ```
 >This is a blockquote
 with some content
 
 >this is another blockquote
+
+> Everyone thinks of changing the world,
+but no one thinks of changing himself.
+>- Leo Tolstoy
 ```
 
 ### Paragraph

--- a/src-cljx/markdown/transformers.cljx
+++ b/src-cljx/markdown/transformers.cljx
@@ -290,7 +290,9 @@
     (:blockquote state)
     (if (or eof (empty? (string/trim text)))
       ["</p></blockquote>" (assoc state :blockquote false)]
-      [(str text " ") state])
+      (if (.startsWith text ">-")
+        [(str "</p><footer>" (.substring text 2) "</footer><p>") state]
+        [(str text " ") state]))
 
     :default
     (if (= \> (first text))

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -179,6 +179,14 @@
   (is (= "<blockquote><p>Foo bar baz </p></blockquote>"
          (markdown/md-to-html-string ">Foo bar baz"))))
 
+(deftest blockquote-footer
+  (is (= "<blockquote><p> Foo bar baz </p><footer> Leo Tolstoy</footer><p></p></blockquote>"
+         (markdown/md-to-html-string "> Foo bar baz\n>- Leo Tolstoy"))))
+
+(deftest blockquote-empty-footer
+  (is (= "<blockquote><p> Foo bar baz </p><footer></footer><p></p></blockquote>"
+         (markdown/md-to-html-string "> Foo bar baz\n>-"))))
+
 (deftest escaped-characters
   (is
     (= "<p>&#42;&#8216;&#95;&#123;&#125;&#91;&#93;<em>foo</em><code>test</code><i>bar</i>{x}[y]</p>"


### PR DESCRIPTION
I needed the ability to add authors for quotes.  Adding `>-` to the syntax enables a `footer` element inside of the `blockquote` which can be formatted to display the author.
