### PR TITLE
Rename parse-referenes to parse-references

### DIFF
--- a/src-cljs/markdown/core.cljs
+++ b/src-cljs/markdown/core.cljs
@@ -18,7 +18,7 @@
 (defn format "Removed from cljs.core 0.0-1885, Ref. http://goo.gl/su7Xkj"
   [fmt & args] (apply goog.string/format fmt args))
 
-(defn parse-referenes [lines]
+(defn parse-references [lines]
   (let [references (atom {})]
     (doseq [line lines]
       (parse-reference-link line references))
@@ -32,7 +32,7 @@
     (let [params      (when params (apply (partial assoc {}) params))
           lines       (.split text "\n")
           html        (goog.string.StringBuffer. "")
-          references  (when (:reference-links? params) (parse-referenes lines))
+          references  (when (:reference-links? params) (parse-references lines))
           transformer (init-transformer params)]
       (loop [[line & more] lines
              state (merge {:clojurescript true

--- a/src/markdown/core.clj
+++ b/src/markdown/core.clj
@@ -20,7 +20,7 @@
         (write writer text)
         new-state))))
 
-(defn parse-referenes [in]
+(defn parse-references [in]
   (let [references (atom {})]
     (if (instance? java.io.StringReader in)
       (do
@@ -38,7 +38,7 @@
   (binding [markdown.transformers/*substring* (fn [^String s n] (.substring s n))
             markdown.transformers/formatter clojure.core/format]
     (let [params (when params (apply (partial assoc {}) params))
-          references (when (:reference-links? params) (parse-referenes in))]
+          references (when (:reference-links? params) (parse-references in))]
       (with-open [^java.io.BufferedReader rdr (io/reader in)
                   ^java.io.BufferedWriter wrt (io/writer out)]
         (let [transformer (init-transformer wrt params)]


### PR DESCRIPTION
Hi.

I wasn't sure if the naming here was deliberate. Apologies if it was. Thanks for building this.

All the best,
O-I