### PR TITLE
Changes for heading parser

### DIFF
--- a/src-cljx/markdown/transformers.cljx
+++ b/src-cljx/markdown/transformers.cljx
@@ -143,6 +143,7 @@
 (defn heading-text [text]
   (->> text
        (drop-while #(or (= \# %) (= \space %)))
+       (take-while #(not= \# %))
        (string/join)
        (string/trim)))
 

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -5,16 +5,23 @@
 (deftest heading1
   (is (= "<h1>Foo</h1>" (markdown/md-to-html-string " # Foo")))
   (is (= "<h1>foo</h1>" (markdown/md-to-html-string "#foo")))
-  (is (= "<h1>foo</h1>" (markdown/md-to-html-string "foo\n==="))))
+  (is (= "<h1>foo</h1>" (markdown/md-to-html-string "foo\n===")))
+  (is (= "<h1>foo</h1>" (markdown/md-to-html-string "#foo#")))
+  (is (= "<h1>foo</h1>" (markdown/md-to-html-string "#foo#\n"))))
 
 (deftest heading2
   (is (= "<h2>foo</h2>" (markdown/md-to-html-string "##foo")))
-  (is (= "<h2>foo</h2>" (markdown/md-to-html-string "foo\n---"))))
+  (is (= "<h2>foo</h2>" (markdown/md-to-html-string "foo\n---")))
+  (is (= "<h2>foo</h2>" (markdown/md-to-html-string "##foo##")))
+  (is (= "<h2>foo</h2>" (markdown/md-to-html-string "##foo##\n"))))
 
 (deftest heading-with-complex-anchor
   (is (=
         "<h3><a name=\"foo&#95;bar&#95;baz\"></a>foo bar BAz</h3>some text"
-        (markdown/md-to-html-string "###foo bar BAz\nsome text" :heading-anchors true))))
+        (markdown/md-to-html-string "###foo bar BAz\nsome text" :heading-anchors true)))
+  (is (=
+        "<h3><a name=\"foo&#95;bar&#95;baz\"></a>foo bar BAz</h3>some text"
+        (markdown/md-to-html-string "###foo bar BAz##\nsome text" :heading-anchors true))))
 
 (deftest br
   (is (= "<p>foo<br /></p>" (markdown/md-to-html-string "foo  ")))


### PR DESCRIPTION
According to this documentation:
http://daringfireball.net/projects/markdown/syntax#header

"Atx-style headers use 1-6 hash characters at the start of the line, corresponding to header levels 1-6." 

This works correctly, but the same documentation adds:

"Optionally, you may “close” atx-style headers. This is purely cosmetic — you can use this if you think it looks better. The closing hashes don’t even need to match the number of hashes used to open the header. (The number of opening hashes determines the header level.) :

\# This is an H1 \#

\#\# This is an H2 \#\#

\#\#\# This is an H3 #\#\#\#\#
"
in current version of `markdown-clj` this doesn't work. This is my proposition how  to fix that.

If this isn't proper solution, I'm open to any comments and changes.