### PR TITLE
Fix For Processing Bold/Italic/Em/Strong In Link Titles

### DIFF
--- a/src-cljx/markdown/transformers.cljx
+++ b/src-cljx/markdown/transformers.cljx
@@ -322,6 +322,14 @@
       (concat "[" (img alt url (not-empty title)) (rest zy)))
     xs))
 
+(defn process-link-title [title state]
+  (let [italicized (first (italics title state))
+        emphasized (first (em italicized state))
+        stronged   (first (strong emphasized state))
+        bolded     (first (bold stronged state))
+        struck     (first (strikethrough bolded state))]
+    struck))
+
 (defn link [text {:keys [code codeblock] :as state}]
   (if (or code codeblock)
     [text state]
@@ -339,15 +347,15 @@
           (if (or (< (count link) 2)
                   (< (count tail) 1)
                   (> (count dud) 1))
-            (recur (concat out head title dud link) tail)
+            (recur (concat out head (process-link-title title state) dud link) tail)
             (recur
               (into out
                     (if (= (last head) \!)
                       (let [alt (rest title)
                             [url title] (split-with (partial not= \space) (rest link))
-                            title (string/join (rest title))]
+                            title (process-link-title (string/join (rest title)) state)]
                         (concat (butlast head) (img alt url title)))
-                      (concat head (href (rest title) (rest link)))))
+                      (concat head (href (rest (process-link-title title state)) (rest link)))))
               (rest tail))))))))
 
 (defn reference [text]

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -172,6 +172,19 @@
   (is (= "<ul><li><a href='http://github.com/&#42;'>github</a></li></ul>"
          (markdown/md-to-html-string "* [github](http://github.com/*)"))))
 
+(deftest styled-link
+  (is (= "<p><a href='http://github.com'><em>github</em></a></p>"
+         (markdown/md-to-html-string "[*github*](http://github.com)")))
+  (is (= "<p><a href='http://github.com'><i>github</i></a></p>"
+         (markdown/md-to-html-string "[_github_](http://github.com)")))
+  (is (= "<p><a href='http://github.com'><b>github</b></a></p>"
+         (markdown/md-to-html-string "[__github__](http://github.com)")))
+  (is (= "<p><a href='http://github.com'><strong>github</strong></a></p>"
+         (markdown/md-to-html-string "[**github**](http://github.com)")))
+  (is (= "<p><a href='http://github.com'><del>github</del></a></p>"
+         (markdown/md-to-html-string "[~~github~~](http://github.com)")))
+  )
+
 (deftest img
   (is (= "<p><img src=\"/path/to/img.jpg\" alt=\"Alt text\" /></p>"
          (markdown/md-to-html-string "![Alt text](/path/to/img.jpg)")))
@@ -240,4 +253,3 @@
 (deftest not-a-list
   (is (= "<p>The fish was 192.8 lbs and was amazing to see.</p>"
          (markdown/md-to-html-string "The fish was\n192.8 lbs and was amazing to see."))))
-


### PR DESCRIPTION
Has tests!

Probably is not "up - to - snuff" on the actual code, but I hope this is good enough.

Fixes: https://github.com/yogthos/markdown-clj/issues/51