### PR TITLE
Close paragraphs before opening lists

### DIFF
--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -212,6 +212,9 @@
 (defn paragraph
   [text {:keys [eof heading hr code lists blockquote paragraph last-line-empty?] :as state}]
   (cond
+    (and paragraph lists)
+    [(str "</p>" text) (assoc state :paragraph false)]
+
     (or heading hr code lists blockquote)
     [text state]
 

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -237,6 +237,10 @@
   (is (= "<ol><li>a</li><li>b</li></ol><p>test <strong>bold</strong> and <em>italic</em></p>"
          (markdown/md-to-html-string"1. a\n2. b\n\ntest **bold** and *italic*"))))
 
+(deftest paragraph-close-before-list
+  (is (= "<p>in paragraph</p><ul><li>list</li></ul>"
+         (markdown/md-to-html-string "in paragraph\n- list"))))
+
 (deftest autourl
   (is (= "<p><a href=\"http://example.com/\">http://example.com/</a></p>"
          (markdown/md-to-html-string "<http://example.com/>")))


### PR DESCRIPTION
In cases where a list immediately follows a paragraph without an extra
new line between them, the paragraph may never close, e.g.

```markdown
foo
- bar
```

would convert to,

```html
<p>foo<ul><li>bar</li></ul>
```