### PR TITLE
Add metadata parsing support for Clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ To enable footnotes, pass the `:footnotes? true` option:
   :footnotes? true)
 ```
 
+### Metadata
+
+To enable parsing of metadata, pass the `:parse-meta? true` option. This will change the output of the function to a map with contains two keys, `:html` which contains all the parsed HTML, and `:metadata` which will contain a map of all metadata included at the top of the document. The metadata format is based on the syntax described by [MultiMarkdown](https://github.com/fletcher/MultiMarkdown/wiki/MultiMarkdown-Syntax-Guide#metadata). 
+
+The value of each key in the metadata map will be a list of either 0, 1 or many strings. If a metadata value ends in two spaces then the string will end in a newline. If a line does not contain a header and has at least 4 spaces in front of it then it will be considered to be a member of the last key that was found.
+
+```clojure
+(md-to-html-string
+  "Author: Rexella van Imp
+    Kim Jong-un    
+Date: October 31, 2015
+   
+   # Hello!" :parse-meta? true)
+
+{:metadata {:author ["Rexella van Imp"
+                     "Kim Jong-un"], 
+            :date ["October 31, 2015"]}, 
+ :html "<h1>Hello!</h1>"}
+``` 
+
 ## Customizing the Parser
 
 Additional transformers can be specified using the `:custom-transformers` key.

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -1,8 +1,9 @@
 (ns markdown.core
   (:use [markdown.transformers
          :only [*next-line* *substring* transformer-vector parse-reference parse-reference-link
-                parse-footnote-link footer]])
-  (:require [clojure.java.io :as io])
+                parse-footnote-link footer parse-metadata-headers]])
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string])
   (:import [java.io BufferedReader
                     BufferedWriter
                     StringReader
@@ -47,16 +48,35 @@
         (parse-footnote-link line footnotes)))
     @footnotes))
 
+(defn parse-metadata [in]
+  (let [lines (line-seq (io/reader in))
+        metadata (parse-metadata-headers lines)]
+    (when (instance? StringReader in)
+      (.reset in))
+    metadata))
+
+(defn parse-params
+  [params]
+  (when (not= 0 (mod (count params) 2))
+    (throw (IllegalArgumentException.
+             "Must supply an even number of parameters")))
+  (when params (apply (partial assoc {}) params)))
+
 (defn md-to-html
-  "reads markdown content from the input stream and writes HTML to the provided output stream"
+  "reads markdown content from the input stream and writes HTML to the provided
+  output stream. If metadata was requested to be parsed it is returned, otherwise
+  nil is returned."
   [in out & params]
   (binding [markdown.transformers/*substring* (fn [^String s n] (.substring s n))
             markdown.transformers/formatter clojure.core/format]
-    (let [params     (when params (apply (partial assoc {}) params))
+    (let [params (parse-params params)
           references (when (:reference-links? params) (parse-references in))
-          footnotes (when (:footnotes? params) (parse-footnotes in))]
+          footnotes (when (:footnotes? params) (parse-footnotes in))
+          metadata (when (:parse-meta? params) (parse-metadata in))]
       (with-open [^BufferedReader rdr (io/reader in)
                   ^BufferedWriter wrt (io/writer out)]
+        (when (and metadata (:parse-meta? params))
+          (while (not= "" (string/trim (.readLine rdr)))))
         (let [transformer (init-transformer wrt params)]
           (loop [^String line (.readLine rdr)
                  next-line    (.readLine rdr)
@@ -76,13 +96,17 @@
                        (assoc (transformer line next-line state)
                          :last-line-empty? (empty? (.trim line))))
                 (transformer (footer (:footnotes state)) nil (assoc state :eof true))))))
-        (.flush wrt)))))
+        (.flush wrt)
+        metadata))))
 
 (defn md-to-html-string
   "converts a markdown formatted string to an HTML formatted string"
   [text & params]
   (when text
     (let [input  (new StringReader text)
-          output (new StringWriter)]
-      (apply (partial md-to-html input output) params)
-      (.toString output))))
+          output (new StringWriter)
+          metadata (apply (partial md-to-html input output) params)
+          html (.toString output)]
+      (if (:parse-meta? (parse-params params))
+        {:metadata metadata :html html}
+        html))))

--- a/test/mdtests.clj
+++ b/test/mdtests.clj
@@ -283,3 +283,19 @@
 (deftest two-links-tests-link-processing
   (is (= "<h2>When you have a pair of links <a href='http://123.com/1'>link1</a> and you want both <a href='That's crazy'>Wow</a></h2>"
       (markdown/md-to-html-string "## When you have a pair of links [link1](http://123.com/1) and you want both [Wow](That's crazy)"))))
+
+(deftest md-metadata
+  (testing "Finds all metadata and correctly parses rest of file."
+    (let [md (slurp (str "test/metadata.md"))
+          {:keys [metadata html]} (markdown/md-to-html-string
+                                    md :parse-meta? true)]
+      (is (= "<h1>The Document</h1>" html))
+      (is (= {:title ["My Document"]
+              :summary ["A brief description of my document."]
+              :authors ["Justin May"
+                        "Spooky Mulder"
+                        "End Line At End\n"]
+              :date ["October 31, 2015"]
+              :blank-value []
+              :base_url ["http://example.com"]}
+             metadata)))))

--- a/test/metadata.md
+++ b/test/metadata.md
@@ -1,0 +1,10 @@
+Title:   My Document
+Summary: A brief description of my document.
+Authors: Justin May
+         Spooky Mulder
+         End Line At End  
+Date:    October 31, 2015
+blank-value:
+base_url: http://example.com
+
+# The Document


### PR DESCRIPTION
This PR addresses issue #46 and enables metadata parsing. I didn't add any support for Clojurescript since I'm not really sure how you would want that handled, but all the parsing code is contained in the `transformers.cljc` file, so it should be fairly easy to add it.