### PR TITLE
[POC: **don't merge**] add $literal$ separator

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject markdown-clj "0.9.89-literal"
+(defproject markdown-clj "0.9.89+literal"
   :description "Markdown parser"
   :url "https://github.com/yogthos/markdown-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject markdown-clj "0.9.89"
+(defproject markdown-clj "0.9.89-literal"
   :description "Markdown parser"
   :url "https://github.com/yogthos/markdown-clj"
   :license {:name "Eclipse Public License"

--- a/src/cljc/markdown/common.cljc
+++ b/src/cljc/markdown/common.cljc
@@ -40,8 +40,8 @@
 
 (defn escape-code [s]
   (-> s
-      (string/replace #"\$" "&#36;")
       (string/replace #"&" "&amp;")
+      (string/replace #"\$" "&#36;")
       (string/replace #"\*" "&#42;")
       (string/replace #"\^" "&#94;")
       (string/replace #"\_" "&#95;")

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -15,6 +15,7 @@
               escaped-chars
               separator
               thaw-strings
+              literal
               strong
               bold
               em
@@ -297,6 +298,7 @@
    code
    escaped-chars
    inline-code
+   literal
    autoemail-transformer
    autourl-transformer
    image


### PR DESCRIPTION
**Note: Don't merge** This PR is implemented in an ugly way and there are no unit tests for the new functionality.  ~~It has at least one known bug (dollar signs within backquotes will show up as `&#36;`)~~ [P.S.: fixed].  Its purpose is just to illustrate a feature that I think would be helpful.  If you agree what I'm proposing is worth doing, I'll work on a more proper implementation.

This PR implements a new separator that prevents any further processing of the text contained within, by making use of `freeze-string`.  The purpose of this is to make it easier to use Markdown together with other conflicting formats, like asciimath or other MathJax input formats.

I've arbitrarily chosen $ as the character to delimit these regions; in the final implementation, the user of the library should be able to choose a character that is convenient for them (e.g., a non-ASCII one).