### PR TITLE
Inhibiting delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,38 @@ Date: October 31, 2015
  :html "<h1>Hello!</h1>"}
 ``` 
 
+### Selectively inhibiting the Parser
+
+If you pass `:inhibit-separator "some-string"`, then any text within occurrences of `some-string` will be output verbatim, eg:
+
+```clojure
+(md-to-html-string "For all %$a_0, a_1, ..., a_n in R$% there is _at least one_ %$b_n in R$% such that..."
+                   :inhibit-separator "%")
+```
+```xml
+For all $a_0, a_1, ..., a_n in R$ there is <i>at least one</i> $b_n in R$ such that...
+```
+
+This may be useful to use `markdown-clj` along with other parsers of languages with conflicting syntax (e.g. asciimath2jax).
+
+If you need to output the separator itself, enter it twice without any text inside.  Eg:
+
+```clojure
+(md-to-html-string "This is one of those 20%% vs 80%% cases."
+                   :inhibit-separator "%")
+```
+```xml
+This is one of those 20% vs 80% cases.
+```
+
+Some caveats:
+
+- Like other tags, this only works within a single line.
+
+- If you remove the default transformers with `:replacement-transformers` (which see below), inhibiting will stop working.
+
+- Currently, dashes (`--` and `---`) can't be suppressed this way.
+
 ## Customizing the Parser
 
 Additional transformers can be specified using the `:custom-transformers` key.

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [markdown.common
-             :refer [*substring*]]
+             :refer [*substring* *inhibit-separator*]]
             [markdown.links
              :refer [parse-reference parse-reference-link parse-footnote-link]]
             [markdown.transformers
@@ -16,9 +16,10 @@
 (defn- write [^Writer writer ^String text]
   (doseq [c text] (.write writer (int c))))
 
-(defn- init-transformer [writer {:keys [replacement-transformers custom-transformers]}]
+(defn- init-transformer [writer {:keys [replacement-transformers custom-transformers inhibit-separator]}]
   (fn [line next-line state]
-    (binding [*next-line* next-line]
+    (binding [*next-line* next-line
+              *inhibit-separator* inhibit-separator]
       (let [[text new-state]
             (reduce
               (fn [[text, state] transformer]

--- a/src/cljc/markdown/common.cljc
+++ b/src/cljc/markdown/common.cljc
@@ -3,6 +3,8 @@
 
 (declare ^{:dynamic true} *substring*)
 
+(def ^:dynamic *inhibit-separator* nil)
+
 (def escape-delimiter (str (char 254) (char 491)))
 
 (defn gen-token [n]
@@ -141,7 +143,19 @@
 
 (def inline-code (make-separator "`" "<code>" "</code>" escape-code-transformer))
 
-(def inline-code (make-separator [\`] "<code>" "</code>" escape-code-transformer))
+(defn inhibit [text state]
+  (if *inhibit-separator*
+    ((make-separator *inhibit-separator* "" "" freeze-string)
+     text state)
+    [text state]))
+
+(defn escape-inhibit-separator [text state]
+  [(if *inhibit-separator*
+     (string/replace text
+                     (string/join (concat *inhibit-separator* *inhibit-separator*))
+                     (string/join *inhibit-separator*))
+     text)
+   state])
 
 (defn heading-text [text]
   (-> (clojure.string/replace text #"^([ ]+)?[#]+" "")

--- a/src/cljc/markdown/common.cljc
+++ b/src/cljc/markdown/common.cljc
@@ -83,41 +83,42 @@
   ([separator open close]
    (make-separator separator open close identity))
   ([separator open close transformer]
-   (fn [text state]
-     (if (:code state)
-       [text state]
-       (loop [out       []
-              buf       []
-              tokens    (partition-by (partial = (first separator)) (seq text))
-              cur-state (assoc state :found-token false)]
-         (cond
-           (empty? tokens)
-           [(string/join (into (if (:found-token cur-state) (into out separator) out) buf))
-            (dissoc cur-state :found-token)]
+   (let [separator (seq separator)]  ;; allow char seq or string
+     (fn [text state]
+       (if (:code state)
+         [text state]
+         (loop [out       []
+                buf       []
+                tokens    (partition-by (partial = (first separator)) (seq text))
+                cur-state (assoc state :found-token false)]
+           (cond
+             (empty? tokens)
+             [(string/join (into (if (:found-token cur-state) (into out separator) out) buf))
+              (dissoc cur-state :found-token)]
 
-           (:found-token cur-state)
-           (if (= (first tokens) separator)
-             (let [[new-buf new-state]
-                   (if (identical? transformer identity)
-                     ;; Skip the buf->string->buf conversions in the common
-                     ;; case.
-                     [buf cur-state]
-                     (let [[s new-state] (transformer (string/join buf) cur-state)]
-                       [(seq s) new-state]))]
-               (recur (vec (concat out (seq open) new-buf (seq close)))
-                      []
+             (:found-token cur-state)
+             (if (= (first tokens) separator)
+               (let [[new-buf new-state]
+                     (if (identical? transformer identity)
+                       ;; Skip the buf->string->buf conversions in the common
+                       ;; case.
+                       [buf cur-state]
+                       (let [[s new-state] (transformer (string/join buf) cur-state)]
+                         [(seq s) new-state]))]
+                 (recur (vec (concat out (seq open) new-buf (seq close)))
+                        []
+                        (rest tokens)
+                        (assoc new-state :found-token false)))
+               (recur out
+                      (into buf (first tokens))
                       (rest tokens)
-                      (assoc new-state :found-token false)))
-             (recur out
-                    (into buf (first tokens))
-                    (rest tokens)
-                    cur-state))
+                      cur-state))
 
-           (= (first tokens) separator)
-           (recur out buf (rest tokens) (assoc cur-state :found-token true))
+             (= (first tokens) separator)
+             (recur out buf (rest tokens) (assoc cur-state :found-token true))
 
-           :default
-           (recur (into out (first tokens)) buf (rest tokens) cur-state)))))))
+             :default
+             (recur (into out (first tokens)) buf (rest tokens) cur-state))))))))
 
 (defn escape-code-transformer [text state]
   [(escape-code text) state])
@@ -128,15 +129,17 @@
   ((make-separator separator open close (if escape? escape-code-transformer identity))
    text state))
 
-(def strong (make-separator [\* \*] "<strong>" "</strong>"))
+(def strong (make-separator "**" "<strong>" "</strong>"))
 
-(def bold (make-separator [\_ \_] "<b>" "</b>"))
+(def bold (make-separator "__" "<b>" "</b>"))
 
-(def em (make-separator [\*] "<em>" "</em>"))
+(def em (make-separator "*" "<em>" "</em>"))
 
-(def italics (make-separator [\_] "<i>" "</i>"))
+(def italics (make-separator "_" "<i>" "</i>"))
 
-(def strikethrough (make-separator [\~ \~] "<del>" "</del>"))
+(def strikethrough (make-separator "~~" "<del>" "</del>"))
+
+(def inline-code (make-separator "`" "<code>" "</code>" escape-code-transformer))
 
 (def inline-code (make-separator [\`] "<code>" "</code>" escape-code-transformer))
 

--- a/src/cljc/markdown/common.cljc
+++ b/src/cljc/markdown/common.cljc
@@ -75,57 +75,70 @@
          (string/replace #"\\!" "&#33;")))
    state])
 
+(defn make-separator
+  "Return a transformer to
+   - find all the chunks of the string delimited by the `separator',
+   - wrap the output with the `open' and `close' markers, and
+   - apply the `transformer' to the text inside the chunk."
+  ([separator open close]
+   (make-separator separator open close identity))
+  ([separator open close transformer]
+   (fn [text state]
+     (if (:code state)
+       [text state]
+       (loop [out       []
+              buf       []
+              tokens    (partition-by (partial = (first separator)) (seq text))
+              cur-state (assoc state :found-token false)]
+         (cond
+           (empty? tokens)
+           [(string/join (into (if (:found-token cur-state) (into out separator) out) buf))
+            (dissoc cur-state :found-token)]
+
+           (:found-token cur-state)
+           (if (= (first tokens) separator)
+             (let [[new-buf new-state]
+                   (if (identical? transformer identity)
+                     ;; Skip the buf->string->buf conversions in the common
+                     ;; case.
+                     [buf cur-state]
+                     (let [[s new-state] (transformer (string/join buf) cur-state)]
+                       [(seq s) new-state]))]
+               (recur (vec (concat out (seq open) new-buf (seq close)))
+                      []
+                      (rest tokens)
+                      (assoc new-state :found-token false)))
+             (recur out
+                    (into buf (first tokens))
+                    (rest tokens)
+                    cur-state))
+
+           (= (first tokens) separator)
+           (recur out buf (rest tokens) (assoc cur-state :found-token true))
+
+           :default
+           (recur (into out (first tokens)) buf (rest tokens) cur-state)))))))
+
+(defn escape-code-transformer [text state]
+  [(escape-code text) state])
+
+;; Not used any more internally; kept around just in case third party code
+;; depends on this.
 (defn separator [escape? text open close separator state]
-  (if (:code state)
-    [text state]
-    (loop [out       []
-           buf       []
-           tokens    (partition-by (partial = (first separator)) (seq text))
-           cur-state (assoc state :found-token false)]
-      (cond
-        (empty? tokens)
-        [(string/join (into (if (:found-token cur-state) (into out separator) out) buf))
-         (dissoc cur-state :found-token)]
+  ((make-separator separator open close (if escape? escape-code-transformer identity))
+   text state))
 
-        (:found-token cur-state)
-        (if (= (first tokens) separator)
-          (recur (vec
-                   (concat
-                     out
-                     (seq open)
-                     (if escape? (seq (escape-code (string/join buf))) buf)
-                     (seq close)))
-                 []
-                 (rest tokens)
-                 (assoc cur-state :found-token false))
-          (recur out
-                 (into buf (first tokens))
-                 (rest tokens)
-                 cur-state))
+(def strong (make-separator [\* \*] "<strong>" "</strong>"))
 
-        (= (first tokens) separator)
-        (recur out buf (rest tokens) (assoc cur-state :found-token true))
+(def bold (make-separator [\_ \_] "<b>" "</b>"))
 
-        :default
-        (recur (into out (first tokens)) buf (rest tokens) cur-state)))))
+(def em (make-separator [\*] "<em>" "</em>"))
 
-(defn strong [text state]
-  (separator false text "<strong>" "</strong>" [\* \*] state))
+(def italics (make-separator [\_] "<i>" "</i>"))
 
-(defn bold [text state]
-  (separator false text "<b>" "</b>" [\_ \_] state))
+(def strikethrough (make-separator [\~ \~] "<del>" "</del>"))
 
-(defn em [text state]
-  (separator false text "<em>" "</em>" [\*] state))
-
-(defn italics [text state]
-  (separator false text "<i>" "</i>" [\_] state))
-
-(defn strikethrough [text state]
-  (separator false text "<del>" "</del>" [\~ \~] state))
-
-(defn inline-code [text state]
-  (separator true text "<code>" "</code>" [\`] state))
+(def inline-code (make-separator [\`] "<code>" "</code>" escape-code-transformer))
 
 (defn heading-text [text]
   (-> (clojure.string/replace text #"^([ ]+)?[#]+" "")

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -21,6 +21,8 @@
               italics
               strikethrough
               inline-code
+              escape-inhibit-separator
+              inhibit
               make-heading
               dashes]]))
 
@@ -293,6 +295,8 @@
 (def transformer-vector
   [set-line-state
    empty-line
+   inhibit
+   escape-inhibit-separator
    codeblock
    code
    escaped-chars

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -1,14 +1,16 @@
 (ns markdown.core
   (:require [markdown.common
-             :refer [*substring*]]
+             :refer [*substring* *inhibit-separator*]]
             [markdown.links
              :refer [parse-reference parse-reference-link parse-footnote-link]]
             [markdown.transformers
              :refer [*next-line*  transformer-vector footer parse-metadata-headers]]))
 
-(defn- init-transformer [{:keys [replacement-transformers custom-transformers]}]
+
+(defn- init-transformer [{:keys [replacement-transformers custom-transformers inhibit-separator]}]
   (fn [html line next-line state]
-    (binding [*next-line* next-line]
+    (binding [*next-line* next-line
+              *inhibit-separator* inhibit-separator]
       (let [[text new-state]
             (reduce
               (fn [[text state] transformer]

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -162,7 +162,7 @@
 ```
 "))))
 
-(deftest stirkethrough
+(deftest strikethrough
   (is (= "<p><del>foo</del></p>"
          (entry-function "~~foo~~"))))
 
@@ -329,3 +329,30 @@
 
 (deftest m-dash
   (is (= "<p>boo &mdash; bar</p>" (entry-function "boo --- bar"))))
+
+(deftest inhibit-simple
+  (is (= "<p>_abc_</p>" (entry-function "$_abc_$" :inhibit-separator "$"))))
+
+(deftest inhibit-simple-seq
+  (is (= "<p>_abc_</p>" (entry-function "$_abc_$" :inhibit-separator [\$]))))
+
+(deftest inhibit-inline-code
+  (is (= "<p>`abc`</p>" (entry-function "$`abc`$" :inhibit-separator [\$]))))
+
+(deftest inhibit-inside-code
+  (is (= "<p><code>a*b* & dc</code></p>" (entry-function "`a$*b* & d$c`" :inhibit-separator "$"))))
+
+(deftest inhibit-across-backticks
+  (is (= "<p><code>one` `two</code></p>" (entry-function "`one$` `$two`" :inhibit-separator "$"))))
+
+(deftest inhibit-escape
+  (is (= "<p>$</p>" (entry-function "$$" :inhibit-separator [\$]))))
+
+(deftest inhibit-escape-twice
+  (is (= "<p>$$</p>") (entry-function "$$$$" :inhibit-separator "$")))
+
+(deftest dont-inhibit-text-within-escapes
+  (is (= "<p>$<em>abc</em>$</p>" (entry-function "$$*abc*$$" :inhibit-separator "$"))))
+
+(deftest inhibit-escape-inside-code
+  (is (= "<p><code>$</code></p>" (entry-function "`$$`" :inhibit-separator "$"))))


### PR DESCRIPTION
The individual commits are meant to make the change easier to understand.  Please see the comments in those, and the change in the README.

In short: the main entry functions gain a new `:inhibit-separator` optional argument.  If truthy, it must be a seq of chars or a string.  Text contained within the given separators will not be processed by markdown (but will still be affected by any tags generated around it).

Caveats:

- Like other similar separators, this one only works in a single line.

- If you remove the `inhibit` transformer with `replace-transformers`, this will stop working.

- I don't suppose it can suppress dashes.  For some reason, these get processed after `thaw-strings`.  I haven't changed this because it might break existing code, but I think putting `dashes` before `thaw-strings` should be considered for the next breaking release.