### PR TITLE
Add support for .-_<spc> in references

### DIFF
--- a/src/cljc/markdown/links.cljc
+++ b/src/cljc/markdown/links.cljc
@@ -77,7 +77,7 @@
 (def image (make-link true))
 
 (defn reference [text]
-  (re-find #"^\[[a-zA-Z0-9 ]+\]:" text))
+  (re-find #"^\[[a-zA-Z0-9 \-_\.]+\]:" text))
 
 (defn parse-reference [reference start]
   (-> reference
@@ -113,7 +113,7 @@
 (defn freeze-links [references text state]
   (let [links
         (re-seq
-          #"\[[^\]]+\]\s*\[[a-zA-Z0-9 ]+\]"
+          #"\[[^\]]+\]\s*\[[a-zA-Z0-9 \-_\.]+\]"
           text)
         encoded-links
         (encode-links links ((fnil count []) (:frozen-strings state)))]

--- a/test/files/references.md
+++ b/test/files/references.md
@@ -19,7 +19,7 @@ This is an implicit reference-style link to [id1][].
 
 Then, anywhere in the document, you define your link label like this, on a line by itself:
 
-This is [an example][id2] reference-style link.
+This is [an example][id-2] reference-style link.
 
 This is [an example][id3] reference-style link.
 
@@ -27,7 +27,7 @@ A link with [an underscore][underscore].
 
 [id1]: http://example.com/  'Optional Title Here'
 
-[id2]: http://example.com/  (Optional Title Here)
+[id-2]: http://example.com/  (Optional Title Here)
 
 [id3]: http://example.com/
 


### PR DESCRIPTION
This regex could probably be enhanced by ensuring that there's at least
one non-whitespace character.

I haven't checked if the footnote regex needs extending, as I don't personally use that feature, and I was running short on time.