### PR TITLE
Failing test for bullets in blockquotes

### DIFF
--- a/src/cljc/markdown/lists.cljc
+++ b/src/cljc/markdown/lists.cljc
@@ -42,6 +42,8 @@
     (add-row :ol list-type num-indents indents (or (make-heading content false) content) state)))
 
 (defn li [text {:keys [code codeblock last-line-empty? eof lists] :as state}]
+  (println "in li with:" text)
+  (println state)
   (cond
 
     (and last-line-empty? (string/blank? text))

--- a/src/cljc/markdown/lists.cljc
+++ b/src/cljc/markdown/lists.cljc
@@ -42,8 +42,8 @@
     (add-row :ol list-type num-indents indents (or (make-heading content false) content) state)))
 
 (defn li [text {:keys [code codeblock last-line-empty? eof lists] :as state}]
-  (println "in li with:" text)
-  (println state)
+  ;;(println "in li with:" text)
+  ;;(println state)
   (cond
 
     (and last-line-empty? (string/blank? text))

--- a/src/cljc/markdown/lists.cljc
+++ b/src/cljc/markdown/lists.cljc
@@ -42,8 +42,6 @@
     (add-row :ol list-type num-indents indents (or (make-heading content false) content) state)))
 
 (defn li [text {:keys [code codeblock last-line-empty? eof lists] :as state}]
-  ;;(println "in li with:" text)
-  ;;(println state)
   (cond
 
     (and last-line-empty? (string/blank? text))

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -254,11 +254,8 @@
     (cond (not blockquote-end)
           [text state]
           
-          (and (not list-end) blockquote-paragraph)
-          [(str text "</p>") (dissoc state :blockquote-paragraph)]
-          
           list-end
-          [(str text "</blockquote>")
+          [(str text (when blockquote-paragraph "</p>") "</blockquote>")
            (dissoc state :blockquote :blockquote-paragraph :blockquote-end )]
           
           :default

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -228,7 +228,7 @@
 
       (:blockquote state)
       (cond (or eof (empty? trimmed))
-            [text (assoc state :blockquote-end true)]
+            [text (assoc state :blockquote-end true :blockquote false)]
 
             (= ">" trimmed)
             [(str (when (:blockquote-paragraph state) "</p>") "<p>") (assoc state :blockquote-paragraph true)]
@@ -250,18 +250,19 @@
 (defn blockquote-end [text {:keys [blockquote-end blockquote-paragraph lists] :as state}]
   (println "in blockquote-end with:" text)
   (println state)
-  (cond (not blockquote-end)
-        [text state]
-
-        (and lists blockquote-paragraph)
-        ["</p>" (dissoc state :blockquote-paragraph)]
-
-        (not lists)
-        ["</blockquote>"
-         (dissoc state :blockquote :blockquote-paragraph :blockquote-end )]
-
-        :default
-        [text state]))
+  (let [list-end (or (not lists) (empty? lists))]
+    (cond (not blockquote-end)
+          [text state]
+          
+          (and (not list-end) blockquote-paragraph)
+          [(str text "</p>") (dissoc state :blockquote-paragraph)]
+          
+          list-end
+          [(str text "</blockquote>")
+           (dissoc state :blockquote :blockquote-paragraph :blockquote-end )]
+          
+          :default
+          [text state])))
 
 (defn footer [footnotes]
   (if (empty? (:processed footnotes))

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -219,8 +219,8 @@
       [text state])))
 
 (defn blockquote-start [text {:keys [eof code codeblock lists] :as state}]
-  (println "\nin blockquote-start with:" text)
-  (println state)
+  ;;(println "\nin blockquote-start with:" text)
+  ;;(println state)
   (let [trimmed (string/trim text)]
     (cond
       (or code codeblock)
@@ -248,8 +248,8 @@
         [text state]))))
 
 (defn blockquote-end [text {:keys [blockquote-end blockquote-paragraph lists] :as state}]
-  (println "in blockquote-end with:" text)
-  (println state)
+  ;;(println "in blockquote-end with:" text)
+  ;;(println state)
   (let [list-end (or (not lists) (empty? lists))]
     (cond (not blockquote-end)
           [text state]

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -349,8 +349,8 @@
    hr
    blockquote-1
    li
-   blockquote-2
    heading
+   blockquote-2
    italics
    bold-italic
    em

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -246,7 +246,7 @@
 
       :default
       (if (= \> (first text))
-        [(string/join (rest text))
+        [(str (string/join (rest text)) " ")
          (assoc state :blockquote-start true :blockquote true :blockquote-paragraph true)]
         [text state]))))
 
@@ -255,7 +255,7 @@
   [text {:keys [blockquote-start blockquote-end blockquote-paragraph lists] :as state}]
   (let [list-end (or (not lists) (empty? lists))]
     (cond blockquote-start
-          [(str "<blockquote><p>" text " ")
+          [(str "<blockquote><p>" text)
            (dissoc state :blockquote-start)]
           
           (and blockquote-end list-end)

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -251,14 +251,16 @@
         [text state]))))
 
 (defn blockquote-2
-  "Check for change in blockquote states and add start or end tags"
+  "Check for change in blockquote states and add start or end tags.
+  Closing a blockquote with a list in it is a bit more complex, 
+  as the list is not closed until the following blank line."
   [text {:keys [blockquote-start blockquote-end blockquote-paragraph lists] :as state}]
-  (let [list-end (or (not lists) (empty? lists))]
+  (let [not-in-list (or (not lists) (empty? lists))]
     (cond blockquote-start
           [(str "<blockquote><p>" text)
            (dissoc state :blockquote-start)]
           
-          (and blockquote-end list-end)
+          (and blockquote-end not-in-list)
           [(str text (when blockquote-paragraph "</p>") "</blockquote>")
            (dissoc state :blockquote :blockquote-paragraph :blockquote-end )]
           

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -266,6 +266,12 @@
   (is (= "<blockquote><p><ul><li>foo</li><li>bar</li><li>baz</li></ul></p></blockquote>"
          (entry-function ">* foo\n>* bar\n>* baz"))))
 
+(deftest blockquote-headings
+  (is (= "<blockquote><p><h2>Foo</h2>bar baz </p></blockquote>"
+         (entry-function "> ## Foo\n>bar baz")))
+  (is (= "<blockquote><p> Foo <h2>bar</h2> baz </p></blockquote>"
+         (entry-function "> Foo\n>## bar\n> baz"))))  
+
 (deftest escaped-characters
   (is
     (= "<p>&#42;&#8216;&#95;&#123;&#125;&#91;&#93;<em>foo</em><code>test</code><i>bar</i>{x}[y]</p>"

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -261,8 +261,10 @@
          (entry-function "> Foo bar\n>\n> baz"))))
 
 (deftest blockquote-bullets
+  (is (= "<blockquote><p> list: <ul><li>foo</li><li>bar</li></ul></p></blockquote><p>end.</p>"
+         (entry-function "> list:\n>* foo\n>* bar\n\nend.")))
   (is (= "<blockquote><ul><li>foo</li><li>bar</li><li>baz</li></blockquote>"
-         (entry-function "> * foo\n> * bar\n> * baz"))))
+         (entry-function ">* foo\n>* bar\n>* baz"))))
 
 (deftest escaped-characters
   (is

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -263,7 +263,7 @@
 (deftest blockquote-bullets
   (is (= "<blockquote><p> list: <ul><li>foo</li><li>bar</li></ul></p></blockquote><p>end.</p>"
          (entry-function "> list:\n>* foo\n>* bar\n\nend.")))
-  (is (= "<blockquote><ul><li>foo</li><li>bar</li><li>baz</li></blockquote>"
+  (is (= "<blockquote><p><ul><li>foo</li><li>bar</li><li>baz</li></ul></p></blockquote>"
          (entry-function ">* foo\n>* bar\n>* baz"))))
 
 (deftest escaped-characters

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -260,6 +260,10 @@
   (is (= "<blockquote><p> Foo bar </p><p> baz </p></blockquote>"
          (entry-function "> Foo bar\n>\n> baz"))))
 
+(deftest blockquote-bullets
+  (is (= "<blockquote><ul><li>foo</li><li>bar</li><li>baz</li></blockquote>"
+         (entry-function "> * foo\n> * bar\n> * baz"))))
+
 (deftest escaped-characters
   (is
     (= "<p>&#42;&#8216;&#95;&#123;&#125;&#91;&#93;<em>foo</em><code>test</code><i>bar</i>{x}[y]</p>"


### PR DESCRIPTION
I've split the blockquote function into blockquote-start and blockquote-end, which seems to better handle nested elements. Next to do: handle all the extra <p> tags.