### PR TITLE
Cljs whitespace fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 crossover
 target
 /.lein-*
-
+.idea/*
+*.iml
+.nrepl-port

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -70,7 +70,7 @@
           (if (not-empty more)
             (recur more
                    (assoc (transformer html line (first more) (dissoc state :skip-next-line?))
-                     :last-line-empty? (empty? line)))
+                     :last-line-empty? (empty? (.trim line))))
             (transformer (.append html (footer (:footnotes state))) line "" (assoc state :eof true)))))
       {:metadata metadata :html (.toString html)})))
 

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -413,3 +413,6 @@
 
 (deftest inhibit-escape-inside-code
   (is (= "<p><code>$</code></p>" (entry-function "`$$`" :inhibit-separator "$"))))
+
+(deftest whitespace-paragraphs
+  (is (= "<p>foo  </p><p>bar</p>" (entry-function "foo\n \nbar"))))


### PR DESCRIPTION
Fix bug where whitespace and line breaks can cause text to be rendered without p tag in clojurescript.

For example `foo\n \nbar` would become `<p>foo  </p>bar`