### PR TITLE
Add an API for parsing only metadata.

### DIFF
--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -115,6 +115,13 @@
           html     (.toString output)]
       {:metadata metadata :html html})))
 
+(defn md-to-meta
+  "converts a markdown formatted string to a metadata map"
+  [text]
+  (when text
+    (let [input (new StringReader text)]
+      (parse-metadata input))))
+
 (defn md-to-html-string [text & params]
   (:html (md-to-html-string* text params)))
 

--- a/test/markdown/md_file_test.clj
+++ b/test/markdown/md_file_test.clj
@@ -44,6 +44,20 @@
               :base_url    ["http://example.com"]}
              metadata)))))
 
+(deftest md-metadata-only
+  (testing "Finds all metadata, without parsing the rest of the file."
+    (let [md (slurp (str "test/files/metadata.md"))
+          metadata (markdown/md-to-meta md)]
+      (is (= {:title       ["My Document"]
+              :summary     ["A brief description of my document."]
+              :authors     ["Justin May"
+                            "Spooky Mulder"
+                            "End Line At End\n"]
+              :date        ["October 31, 2015"]
+              :blank-value []
+              :base_url    ["http://example.com"]}
+             metadata)))))
+
 (deftest md-yaml-metadata
   (testing "Finds all yaml metadata and correctly parses rest of file."
     (let [md (slurp (str "test/files/metadata-yaml.md"))


### PR DESCRIPTION
I'm using `markdown-clj` in a scenario where metadata is needed to populate a table of contents, and the HTML is not needed until later, if at all. (It's useful for performance to be able to fetch just the metadata without the full markdown parse.)