### PR TITLE
Updating clj-yaml to version 0.7.107 to fix security vulnerability

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [clj-commons/clj-yaml "0.7.0"]]
+                 [clj-commons/clj-yaml "0.7.107"]]
   :clojurescript? true
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
   :test-selectors {:default   (complement :benchmark)


### PR DESCRIPTION
* clj-yaml 0.7.0 was using snakeyaml version 1.24
* See https://nvd.nist.gov/vuln/detail/CVE-2017-18640#range-6738067