### PR TITLE
Make babashka compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 .idea/*
 *.iml
 .nrepl-port
+.cache
+.cpcache
+cljs-test-runner-out

--- a/bb.edn
+++ b/bb.edn
@@ -4,11 +4,12 @@
            :extra-paths ["test"]
            :extra-deps {io.github.cognitect-labs/test-runner
                         {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
-                        org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
-                                                     :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}}
+                        org.clojure/tools.namespace
+                        {:git/url "https://github.com/babashka/tools.namespace"
+                         :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}}
            :requires ([cognitect.test-runner :as tr])
            :task (apply tr/-main "-d" "test" *command-line-args*)}
   test:clj {:doc "Runs tests with JVM Clojure"
-                :task (clojure "-X:test")}
+            :task (clojure "-X:test")}
   test:cljs {:doc "Runs tests with ClojureScript"
              :task (clojure "-M:cljs-test")}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,14 @@
+{:deps {markdown-clj/markdown-clj {:local/root "."}}
+ :tasks
+ {test:bb {:doc "Runs tests with babashka"
+           :extra-paths ["test"]
+           :extra-deps {io.github.cognitect-labs/test-runner
+                        {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                        org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
+                                                     :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}}
+           :requires ([cognitect.test-runner :as tr])
+           :task (apply tr/-main "-d" "test" *command-line-args*)}
+  test:clj {:doc "Runs tests with JVM Clojure"
+                :task (clojure "-X:test")}
+  test:cljs {:doc "Runs tests with ClojureScript"
+             :task (clojure "-M:cljs-test")}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,17 @@
+{:paths ["src/clj" "src/cljs" "src/cljc"]
+ :deps {clj-commons/clj-yaml {:mvn/version "0.7.107"}}
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                criterium/criterium {:mvn/version "0.4.4"}
+                commons-lang/commons-lang {:mvn/version "2.6"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn cognitect.test-runner.api/test}
+  :cljs-test
+  {:extra-paths ["test"]
+   :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
+                org.clojure/clojure {:mvn/version "1.10.1"}
+                org.clojure/clojurescript {:mvn/version "1.10.520"}}
+   :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/src/cljc/markdown/common.cljc
+++ b/src/cljc/markdown/common.cljc
@@ -1,7 +1,7 @@
 (ns markdown.common
   (:require [clojure.string :as string]))
 
-(declare ^{:dynamic true} *substring*)
+(def ^{:dynamic true} *substring*)
 
 (def ^:dynamic *inhibit-separator* nil)
 

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -1,7 +1,6 @@
 (ns markdown.transformers
   (:require [clojure.string :as string]
-            #?(:clj  [clojure.edn :as edn]
-               :cljs [cljs.reader :as edn])
+            [clojure.edn :as edn]
             [markdown.links
              :refer [link
                      image

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -31,7 +31,7 @@
               dashes]]
             #?(:clj [clj-yaml.core :as yaml])))
 
-(declare ^:dynamic *formatter*)
+(def ^:dynamic *formatter*)
 
 (defn heading? [text type]
   (when-not (every? #{\space} (take 4 text))

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -327,15 +327,19 @@
   (is (= "<p><a href=\"http://foo\">http://foo</a> <a href=\"https://bar/baz\">https://bar/baz</a> <a href=\"http://foo/bar\">foo bar</a></p>"
          (entry-function "<http://foo> <https://bar/baz> <a href=\"http://foo/bar\">foo bar</a>")))
 
-  (is (= "<p><a href=\"mailto:abc@google.com\">abc@google.com</a></p>"
-         (#?(:clj  org.apache.commons.lang.StringEscapeUtils/unescapeHtml
-             :cljs goog.string/unescapeEntities)
-          (entry-function "<abc@google.com>"))))
+  #?(:bb nil
+     :default
+     (is (= "<p><a href=\"mailto:abc@google.com\">abc@google.com</a></p>"
+            (#?(:clj  org.apache.commons.lang.StringEscapeUtils/unescapeHtml
+                :cljs goog.string/unescapeEntities)
+             (entry-function "<abc@google.com>")))))
 
-  (is (= "<p><a href=\"mailto:abc_def_ghi@google.com\">abc_def_ghi@google.com</a></p>"
-         (#?(:clj  org.apache.commons.lang.StringEscapeUtils/unescapeHtml
-             :cljs goog.string/unescapeEntities)
-          (entry-function "<abc_def_ghi@google.com>")))))
+  #?(:bb nil
+     :default
+     (is (= "<p><a href=\"mailto:abc_def_ghi@google.com\">abc_def_ghi@google.com</a></p>"
+            (#?(:clj  org.apache.commons.lang.StringEscapeUtils/unescapeHtml
+                :cljs goog.string/unescapeEntities)
+             (entry-function "<abc_def_ghi@google.com>"))))))
 
 (deftest not-a-list
   (is (= "<p>The fish was 192.8 lbs and was amazing to see.</p>"


### PR DESCRIPTION
This PR makes markdown-clj babashka compatible:

- Currenty SCI doesn't understand the metadata in `declare` so I defined the dynamic vars using `def` which has no impact on the implementation.
- Added a `deps.edn` so this repo can be used as a git dependency.

To run babashka`bb test:bb` to run tests in babashka. This task is defined in `bb.edn`.

While I was at it, I also added a test runner for Clojure and Clojurescript in `bb.edn`:

```
bb test:clj
bb test:cljs
```