### PR TITLE
Metadata parsers return consumed linecount

### DIFF
--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -370,8 +370,9 @@
     [(->> meta-lines
           ;; join together and parse
           (string/join "\n")
-          edn/read-string) 
-     (count meta-lines)]))
+          edn/read-string)
+     ;; count the trailing empty line
+     (inc (count meta-lines))]))
 
 (defn parse-metadata-headers
   "Given a sequence of lines from a markdown document, attempt to parse a

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -36,8 +36,8 @@
     @footnotes))
 
 (defn parse-metadata [lines]
-  (let [[metadata lines] (split-with #(not-empty (.trim %)) lines)]
-    [(parse-metadata-headers metadata) lines]))
+  (let [[metadata num-lines] (parse-metadata-headers lines)]
+    [metadata (drop num-lines lines)]))
 
 (defn md-to-html-string*
   "processes input text line by line and outputs an HTML string"

--- a/test/files/metadata-yaml.md
+++ b/test/files/metadata-yaml.md
@@ -7,6 +7,9 @@ authors:
   - End Line At End  
 date: October 31, 2015
 base_url: http://example.com
+
+
 ---
+
 
 # The Document

--- a/test/markdown/md_file_test.clj
+++ b/test/markdown/md_file_test.clj
@@ -1,5 +1,7 @@
 (ns markdown.md-file-test
   (:require [markdown.core :as markdown]
+            [markdown.transformers :as transformers]
+            [clojure.string :as string]
             [clojure.test :refer :all]))
 
 (deftest references
@@ -37,7 +39,8 @@
 (deftest md-metadata
   (testing "Finds all metadata and correctly parses rest of file."
     (let [md (slurp (str "test/files/metadata.md"))
-          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)]
+          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)
+          [_ line-count] (transformers/parse-metadata-headers (string/split-lines md))]
       (is (= "<h1>The Document</h1>" html))
       (is (= {:title       ["My Document"]
               :summary     ["A brief description of my document."]
@@ -47,7 +50,8 @@
               :date        ["October 31, 2015"]
               :blank-value []
               :base_url    ["http://example.com"]}
-             metadata)))))
+             metadata))
+      (is (= 8 line-count) "Metadata-parser provides correct line count"))))
 
 (deftest md-metadata-only
   (testing "Finds all metadata, without parsing the rest of the file."
@@ -66,7 +70,8 @@
 (deftest md-yaml-metadata
   (testing "Finds all yaml metadata and correctly parses rest of file."
     (let [md (slurp (str "test/files/metadata-yaml.md"))
-          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)]
+          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)
+          [_ line-count] (transformers/parse-metadata-headers (string/split-lines md))]
       (is (= "<h1>The Document</h1>" html))
       (is (= {:title       "My Document"
               :summary     "A brief description of my document."
@@ -75,12 +80,14 @@
                             "End Line At End"]
               :date        "October 31, 2015"
               :base_url    "http://example.com"}
-             metadata)))))
+             metadata))
+      (is (= 12 line-count) "Metadata-parser provides correct line count"))))
 
 (deftest md-edn-metadata
   (testing "Finds edn map metadata and correctly parses rest of file."
     (let [md (slurp (str "test/files/metadata-edn.md"))
-          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)]
+          {:keys [metadata html]} (markdown/md-to-html-string-with-meta md)
+          [_ line-count] (transformers/parse-metadata-headers (string/split-lines md))]
       (is (= "<h1>The Document</h1>" html))
       (is (= {:title       "My Document"
               :summary     "A brief description of my document."
@@ -89,5 +96,6 @@
                             "End Line At End"]
               :date        "October 31, 2015"
               :base_url    "http://example.com"}
-             metadata)))))
+             metadata))
+      (is (= 6 line-count) "Metadata-parser provides correct line count"))))
 


### PR DESCRIPTION
When the metadata parsers return the number
of lines consumed, we can more easily figure
out the correct offset when parsing the rest
of the document.

This fixes an issue where the yaml metadata
parser did not handle empty lines and required
a trailing emptyline after the ending delimiter