### PR TITLE
Allow `:` char in footnote links

### DIFF
--- a/src/cljc/markdown/links.cljc
+++ b/src/cljc/markdown/links.cljc
@@ -153,7 +153,7 @@
     [replacement-text state]))
 
 (defn footnote [text]
-  (re-find #"^\[\^[a-zA-Z0-9_-]+\]:" text))
+  (re-find #"^\[\^[a-zA-Z:0-9_-]+\]:" text))
 
 (defn parse-footnote-link [line footnotes]
   (let [trimmed (string/trim line)]
@@ -167,7 +167,7 @@
     (str "<a href='" link "' id='fnref" next-fn-id "'><sup>" next-fn-id "</sup></a>")))
 
 (defn replace-all-footnote-links [text {:keys [footnotes] :as state}]
-  (let [matcher #"\[\^[a-zA-Z0-9_-]+\]"
+  (let [matcher #"\[\^[a-zA-Z:0-9_-]+\]"
         match (re-find matcher text)]
     (if (nil? match)
       [text state]


### PR DESCRIPTION
`org-mode` uses footnotes of the style `[fn:1]` both at the point in the text where a footnote is linked as well as at the bottom of the text where the footnote is defined[^1].

When these are exported to markdown, they become `[^fn:1]` at the point in text where the footnote is linked and `[^fn:1]: ` at the bottom of the text where the footnote is defined.

The presence of the `:` in the name of the footnote is not currently handled by `markdown-clj`, and due to this these footnotes are not converted correctly.

This PR fixes the regex to allow `:` in the footnote name.

[^1]: See https://orgmode.org/manual/Creating-Footnotes.html

Testing:
- Manual testing of org-mode style footnotes is working
- Manual testing of normal footnotes is working
- `clojure -M:test` all tests passed