### PR TITLE
Bump `clj-yaml` to Patch Vulnerable Dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src/clj" "src/cljs" "src/cljc"]
- :deps {clj-commons/clj-yaml {:mvn/version "0.7.107"}}
+ :deps {clj-commons/clj-yaml {:mvn/version "0.7.109"}}
  :aliases
  {:test
   {:extra-paths ["test"]


### PR DESCRIPTION
Issue:
`clj-yaml` was [bumped](https://github.com/clj-commons/clj-yaml) today to fix a vulnerability in snakeyaml -- our scanner is now picking up `markdown-clj` as including the vulnerable dep :) 

Fix:
Bump version of `clj-yaml`