### PR TITLE
Bump clj-yaml to fix CVE-2022-41854

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [clj-commons/clj-yaml "0.7.109"]]
+                 [clj-commons/clj-yaml "1.0.26"]]
   :clojurescript? true
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
   :test-selectors {:default   (complement :benchmark)


### PR DESCRIPTION
`clj-yaml 1.0.26` has `snakeyaml 1.33` as dependency which fixes CVE-2022-41854