### PR TITLE
feat: add callback on codeblocks

### DIFF
--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -232,8 +232,7 @@
            (assoc state :codeblock-end true :skip-next-line? true)
            (assoc state :code true
                         :codeblock true
-                        :codeblock-lang (if (not-empty lang)
-                                          lang "")
+                        :codeblock-lang lang
                         :codeblock-buf ""))])
 
       codeblock

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -237,8 +237,7 @@
                         :codeblock-buf ""))])
 
       codeblock
-      (let [text (str text "\n")]
-        ["" (assoc state :codeblock-buf (str codeblock-buf text))])
+      ["" (assoc state :codeblock-buf (str codeblock-buf text \newline))] 
 
       :default
       [text state])))


### PR DESCRIPTION
Changed the writing behavior of codeblock transformer (buffering it first)

An example of a use case:

```clojure
(markdown/md-to-html-string "```python\ndef f(x):\n    return x * 2\n```"
                       :codeblock-callback (fn
                                             [code language]
                                             (trim (clygments/highlight code language :html))))
```

Code above would syntax highlight codeblocks without being bothered to convert the Markdown to HTML first then calling libraries like highlight.js with JavaScript

References:
- https://en.wikipedia.org/wiki/Data_buffer
- https://github.com/bfontaine/clygments
- https://pygments.org/