### PR TITLE
feat(codeblock): add option to no escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,14 @@ This can also be used to add preprocessor transformers. For example, if we wante
 It's possible to pass a `:codeblock-callback` function to the parser that will
 postprocess the code as follows: 
 
+You can also pass `:codeblock-no-escape? true` to disable code escaping.
+
 ```clojure
 (markdown/md-to-html-string "```python\ndef f(x):\n    return x * 2\n```"
+                       :codeblock-no-escape? true
                        :codeblock-callback (fn
                                              [code language]
-                                             (trim (clygments/highlight code language :html))))
+                                             (clygments/highlight code language :html)))
 ```
 
 ## Usage ClojureScript

--- a/README.md
+++ b/README.md
@@ -127,23 +127,6 @@ Date: October 31, 2015
  :html "<h1>Hello!</h1>"}
 ```
 
-### Syntax Highlighting
-
-By default markdown-clj will set a class corresponding to the specified language (if any),
-you can then use libraries like [highlight.js](https://highlightjs.org/), [Prism](https://prismjs.com/), etc.
-
-You can pass `:codeblock-callback f` where f is a function that takes 2 arguments, `code` and `language` and should return a string.
-
-With the callback you can pass a function that processes the code, in this case upper-casing it.
-
-```clojure
-(markdown/md-to-html-string 
-  "Code:\n```clojure\n(defn double\n  [x]\n  (* x 2))\n```"
-  :codeblock-callback (fn [code lang] (upper-case code)))
-```
-
-If you need a syntax highlighter, use libraries like [Pygments](https://pygments.org/) with a wrapper like [Clygments](https://github.com/bfontaine/clygments).
-
 ### Selectively inhibiting the Parser
 
 If you pass `:inhibit-separator "some-string"`, then any text within occurrences of `some-string` will be output verbatim, eg:

--- a/src/cljc/markdown/transformers.cljc
+++ b/src/cljc/markdown/transformers.cljc
@@ -195,7 +195,7 @@
              should-close? (assoc :indent-code-end true))]
           [text state])))))
 
-(defn codeblock [text {:keys [codeblock-buf codeblock-lang codeblock-callback codeblock codeblock-end indented-code next-line lists] :as state}]
+(defn codeblock [text {:keys [codeblock-no-escape? codeblock-buf codeblock-lang codeblock-callback codeblock codeblock-end indented-code next-line lists] :as state}]
   (let [trimmed           (string/trim text)
         next-line-closes? (some-> next-line string/trim (string/ends-with? "```"))]
     (cond
@@ -208,8 +208,13 @@
                 (dissoc :code :codeblock :codeblock-end :codeblock-lang :codeblock-buf))]
 
       (and next-line-closes? codeblock)
-      (let [buffered-code (str codeblock-buf text \newline (apply str (first (string/split next-line #"```"))))]
-        [(str (escape-code (str (if codeblock-callback (codeblock-callback buffered-code codeblock-lang) buffered-code))) "</code></pre>")
+      (let [buffered-code (str codeblock-buf text \newline (apply str (first (string/split next-line #"```"))))
+            code (if codeblock-callback (codeblock-callback buffered-code codeblock-lang) buffered-code)]
+        [(str
+           (if codeblock-no-escape?
+             code
+             (escape-code code))
+           "</code></pre>")
          (assoc state :skip-next-line? (not lists)
                       :codeblock-end true
                       :last-line-empty? (not lists))])


### PR DESCRIPTION
when escaping:

<pre><code class="python">&lt;span class=&quot;k&quot;&gt;def&lt;/span&gt; &lt;span class=&quot;nf&quot;&gt;f&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;&#40;&lt;/span&gt;&lt;span class=&quot;n&quot;&gt;x&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;&#41;:&lt;/span&gt;
    &lt;span class=&quot;k&quot;&gt;return&lt;/span&gt; &lt;span class=&quot;n&quot;&gt;x&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;&#42;&lt;/span&gt; &lt;span class=&quot;mi&quot;&gt;2&lt;/span&gt;
&lt;/pre&gt;
</code></pre>

```html
<pre><code class="python">&lt;span class=&quot;k&quot;&gt;def&lt;/span&gt; &lt;span class=&quot;nf&quot;&gt;f&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;&#40;&lt;/span&gt;&lt;span class=&quot;n&quot;&gt;x&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;&#41;:&lt;/span&gt;
    &lt;span class=&quot;k&quot;&gt;return&lt;/span&gt; &lt;span class=&quot;n&quot;&gt;x&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;&#42;&lt;/span&gt; &lt;span class=&quot;mi&quot;&gt;2&lt;/span&gt;
&lt;/pre&gt;
</code></pre>
```

no escaping:

<pre><code class="python"><span class="k">def</span> <span class="nf">f</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span></code></pre>

```html
<pre><code class="python"><span class="k">def</span> <span class="nf">f</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span>
</code></pre>
```

