### PR TITLE
Enable usage of keyword arguments from JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ a string followed by the options as its input, and returns the resulting HTML st
 
 ```javascript
 console.log(markdown.core.mdToHtml("##This is a heading\nwith a paragraph following it"));
+
+// With keyword arguments
+console.log(markdown.core.mdToHtml("##This is a heading\nwith a paragraph following it", "heading-anchors", true));
+
 ```
 
 ## Supported syntax

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -44,7 +44,9 @@
   [text params]
   (binding [markdown.common/*substring* (fn [s n] (apply str (drop n s)))
             markdown.transformers/*formatter* format]
-    (let [params      (when params (apply (partial assoc {}) params))
+    (let [params      (some->> params
+                               (partition 2)
+                               (reduce (fn [m [k v]] (assoc m (keyword k) v)) {}))
           lines       (.split (str text "\n") "\n")
           html        (goog.string.StringBuffer. "")
           references  (when (:reference-links? params) (parse-references lines))

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -30,9 +30,10 @@
   (is (=
         "<h3 id=\"foo_bar_baz\">foo bar BAz</h3><p>some text</p>"
         (entry-function "###foo bar BAz\nsome text" :heading-anchors true)))
-  (is (=
-        "<h3 id=\"foo_bar_baz\">foo bar BAz</h3><p>some text</p>"
-        (entry-function "###foo bar BAz##\nsome text" :heading-anchors true))))
+  #?(:cljs
+      ; Testing that keywords args can be passed as strings, for javascript compatibility
+      (is (= "<h3 id=\"foo_bar_baz\">foo bar BAz</h3><p>some text</p>"
+             (entry-function "###foo bar BAz##\nsome text" "heading-anchors" true)))))
 
 (deftest br
   (is (= "<p>foo<br /></p>" (entry-function "foo  "))))


### PR DESCRIPTION
In javascript, there are no keywords, so we simply convert string to keywords first.
This feature is added to the clojure version as well, mostly because I don't know how to run a make a test only for the JS version.

Fixes
https://github.com/yogthos/markdown-clj/issues/197