### PR TITLE
parsing of references and footnodes more functional

### DIFF
--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -28,29 +28,26 @@
         (write writer text)
         new-state))))
 
+(defn- after-reset [in result]
+  (if (instance? StringReader in) (.reset in))
+  result)
+
 (defn parse-references [in]
-  (let [references (map parse-reference-link (line-seq (io/reader in)))] 
-    (if (instance? StringReader in)
-      (.reset in))
-    (into {} references)))
+  (after-reset in
+               (into {} (map parse-reference-link (line-seq (io/reader in))))))
 
 (defn parse-footnotes [in]
-  (let [footnotes (reduce (fn [footnotes line]
-                            (if-let [footnote (parse-footnote-link line)]
-                              (apply assoc-in footnotes footnote)
-                              footnotes))
-                          {:next-fn-id 1 :processed {} :unprocessed {}}
-                          (line-seq (io/reader in)))]
-    (if (instance? StringReader in)
-      (.reset in))
-    footnotes))
+  (after-reset in
+               (reduce (fn [footnotes line]
+                         (if-let [footnote (parse-footnote-link line)]
+                           (apply assoc-in footnotes footnote)
+                           footnotes))
+                       {:next-fn-id 1 :processed {} :unprocessed {}}
+                       (line-seq (io/reader in)))))
 
 (defn parse-metadata [in]
-  (let [lines    (line-seq (io/reader in))
-        metadata-and-lines (parse-metadata-headers lines)]
-    (when (instance? StringReader in)
-      (.reset in))
-    metadata-and-lines))
+  (after-reset in
+               (parse-metadata-headers (line-seq (io/reader in)))))
 
 (defn parse-params
   [params]

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -30,24 +30,18 @@
 
 (defn parse-references [in]
   (let [references (atom {})]
+    (doseq [line (line-seq (io/reader in))]
+      (parse-reference-link line references))
     (if (instance? StringReader in)
-      (do
-        (doseq [line (line-seq (io/reader in))]
-          (parse-reference-link line references))
-        (.reset in))
-      (doseq [line (line-seq (io/reader in))]
-        (parse-reference-link line references)))
+      (.reset in))
     @references))
 
 (defn parse-footnotes [in]
   (let [footnotes (atom {:next-fn-id 1 :processed {} :unprocessed {}})]
+    (doseq [line (line-seq (io/reader in))]
+      (parse-footnote-link line footnotes))
     (if (instance? StringReader in)
-      (do
-        (doseq [line (line-seq (io/reader in))]
-          (parse-footnote-link line footnotes))
-        (.reset in))
-      (doseq [line (line-seq (io/reader in))]
-        (parse-footnote-link line footnotes)))
+      (.reset in))
     @footnotes))
 
 (defn parse-metadata [in]

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -35,12 +35,17 @@
     (into {} references)))
 
 (defn parse-footnotes [in]
-  (let [footnotes (atom {:next-fn-id 1 :processed {} :unprocessed {}})]
-    (doseq [line (line-seq (io/reader in))]
-      (parse-footnote-link line footnotes))
+  (let [footnotes (reduce (fn [footnotes line]
+                            (if-let [footnote (parse-footnote-link line)]
+                              (apply assoc-in footnotes footnote)
+                              footnotes))
+                          {:next-fn-id 1 :processed {} :unprocessed {}}
+                          (line-seq (io/reader in)))]
     (if (instance? StringReader in)
       (.reset in))
-    @footnotes))
+    footnotes))
+
+(assoc-in {:a 1} [:v :w] 3)
 
 (defn parse-metadata [in]
   (let [lines    (line-seq (io/reader in))

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -29,12 +29,10 @@
         new-state))))
 
 (defn parse-references [in]
-  (let [references (atom {})]
-    (doseq [line (line-seq (io/reader in))]
-      (parse-reference-link line references))
+  (let [references (map parse-reference-link (line-seq (io/reader in)))] 
     (if (instance? StringReader in)
       (.reset in))
-    @references))
+    (into {} references)))
 
 (defn parse-footnotes [in]
   (let [footnotes (atom {:next-fn-id 1 :processed {} :unprocessed {}})]

--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -45,8 +45,6 @@
       (.reset in))
     footnotes))
 
-(assoc-in {:a 1} [:v :w] 3)
-
 (defn parse-metadata [in]
   (let [lines    (line-seq (io/reader in))
         metadata-and-lines (parse-metadata-headers lines)]

--- a/src/cljc/markdown/links.cljc
+++ b/src/cljc/markdown/links.cljc
@@ -99,11 +99,10 @@
       (string/trim)
       (string/split #"\s+" 2)))
 
-(defn parse-reference-link [line references]
+(defn parse-reference-link [line]
   (let [trimmed (string/trim line)]
     (when-let [link (reference trimmed)]
-      (swap! references assoc (subs link 0 (dec (count link)))
-             (parse-reference trimmed (inc (count link)))))))
+      [(subs link 0 (dec (count link))) (parse-reference trimmed (inc (count link)))])))
 
 (defn replace-reference-link [references reference]
   (let [[title id] (string/split reference #"\]\s*" 2)

--- a/src/cljc/markdown/links.cljc
+++ b/src/cljc/markdown/links.cljc
@@ -154,11 +154,11 @@
 (defn footnote [text]
   (re-find #"^\[\^[a-zA-Z:0-9_-]+\]:" text))
 
-(defn parse-footnote-link [line footnotes]
+(defn parse-footnote-link [line]
   (let [trimmed (string/trim line)]
     (when-let [link (footnote trimmed)]
-      (swap! footnotes assoc-in [:unprocessed (subs link 0 (dec (count link)))]
-             (parse-reference trimmed (inc (count link)))))))
+      [[:unprocessed (subs link 0 (dec (count link)))]
+       (parse-reference trimmed (inc (count link)))])))
 
 (defn replace-footnote-link [footnotes footnote]
   (let [next-fn-id (:next-fn-id footnotes)

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -24,16 +24,15 @@
   [fmt & args] (apply goog.string/format fmt args))
 
 (defn parse-references [lines]
-  (let [references (atom {})]
-    (doseq [line lines]
-      (parse-reference-link line references))
-    @references))
+  (into {} (map parse-reference-link lines)))
 
 (defn parse-footnotes [lines]
-  (let [footnotes (atom {:next-fn-id 1 :processed {} :unprocessed {}})]
-    (doseq [line lines]
-      (parse-footnote-link line footnotes))
-    @footnotes))
+  (reduce (fn [footnotes line]
+            (if-let [footnote (parse-footnote-link line)]
+              (apply assoc-in footnotes footnote)
+              footnotes))
+          {:next-fn-id 1 :processed {} :unprocessed {}}
+          lines))
 
 (defn parse-metadata [lines]
   (let [[metadata num-lines] (parse-metadata-headers lines)]


### PR DESCRIPTION
I changed the implementation of `parse-references` and `parse-footnotes`. It is now more functional style.

Functionally I changed nothing. All tests still pass. But it looks like the tests do not cover the cljs version. So in case you accept this pull request, please have an extra look to my changes in core.cljs.

I don't know if you like that PR. Feel free to ignore it, as it does not change or fix anything functionally.

Regarding the performance, I don't know if my change makes a difference. I guess so, because the atoms add extra code for the synchronisation, which is not really needed here. If you want the best performance, you could try to use map (which then could be optimised a lot by the compiler) and then only use reduce for the construction of the result. But without knowing if that makes a difference, it would be premature optimisation.

What probably will make a performance difference, if you parse the references, footnotes and metadata all together.

My motivation was originally to make markdown-clj a parser that emits data structures and not just a text transformation. But I don't know yet if I will do that. it looks like this was never the intention for markdown-clj.