### PR TITLE
parsing now identical for clj and cljs

### DIFF
--- a/src/cljc/markdown/links.cljc
+++ b/src/cljc/markdown/links.cljc
@@ -104,6 +104,9 @@
     (when-let [link (reference trimmed)]
       [(subs link 0 (dec (count link))) (parse-reference trimmed (inc (count link)))])))
 
+(defn parse-references [lines]
+  (into {} (map parse-reference-link lines)))
+
 (defn replace-reference-link [references reference]
   (let [[title id] (string/split reference #"\]\s*" 2)
         [link alt] (get references id)]
@@ -159,6 +162,14 @@
     (when-let [link (footnote trimmed)]
       [[:unprocessed (subs link 0 (dec (count link)))]
        (parse-reference trimmed (inc (count link)))])))
+
+(defn parse-footnotes [lines]
+  (reduce (fn [footnotes line]
+            (if-let [footnote (parse-footnote-link line)]
+              (apply assoc-in footnotes footnote)
+              footnotes))
+          {:next-fn-id 1 :processed {} :unprocessed {}}
+          lines))
 
 (defn replace-footnote-link [footnotes footnote]
   (let [next-fn-id (:next-fn-id footnotes)

--- a/src/cljs/markdown/core.cljs
+++ b/src/cljs/markdown/core.cljs
@@ -2,10 +2,9 @@
   (:require [markdown.common
              :refer [*substring* *inhibit-separator*]]
             [markdown.links
-             :refer [parse-reference parse-reference-link parse-footnote-link]]
+             :refer [parse-references parse-footnotes]]
             [markdown.transformers
              :refer [transformer-vector footer parse-metadata-headers]]))
-
 
 (defn- init-transformer [{:keys [replacement-transformers custom-transformers inhibit-separator]}]
   (fn [html line next-line state]
@@ -22,17 +21,6 @@
 
 (defn format "Removed from cljs.core 0.0-1885, Ref. http://goo.gl/su7Xkj"
   [fmt & args] (apply goog.string/format fmt args))
-
-(defn parse-references [lines]
-  (into {} (map parse-reference-link lines)))
-
-(defn parse-footnotes [lines]
-  (reduce (fn [footnotes line]
-            (if-let [footnote (parse-footnote-link line)]
-              (apply assoc-in footnotes footnote)
-              footnotes))
-          {:next-fn-id 1 :processed {} :unprocessed {}}
-          lines))
 
 (defn parse-metadata [lines]
   (let [[metadata num-lines] (parse-metadata-headers lines)]


### PR DESCRIPTION
I did a few more changes to the code. I try to make core.clj and core.cljs more similar to each others.

The diff is hard to read, so I explain what I did. First I removed everything which is IO related from the parsing functions. They now accept a (lazy) list of strings. The code that delivers this list of strings have actually not changed, only moved. And after having done this, the two parsing functions become identical for clj and cljs. So I moved them into the cljc area.

I could also try to make init-transformer common.

I don't know if all this is worth the effort. I actually have no concrete goal. I do this just for fun in order to get more experienced with Clojure. So you can decide if you also like this PR.