### PR TITLE
Update `clj-yaml` to `1.0.29`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [clj-commons/clj-yaml "1.0.26"]]
+                 [clj-commons/clj-yaml "1.0.29"]]
   :clojurescript? true
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
   :test-selectors {:default   (complement :benchmark)
@@ -12,16 +12,16 @@
                    :all       (constantly true)}
   :auto-clean false
 
-   :aliases {"test-cljs" ["shell" "bb" "test:cljs"]
-             "test-bb"   ["shell" "bb" "test:bb"]
-             "test-nbb"  ["shell" "bb" "test:nbb"]
-             "test"      ["do" "test," "test-cljs", "test-bb", "test-nbb"]
-             "cleantest" ["do" "clean," "test"]
-             "install"   ["do" "clean," "install"]
-             "deploy"    ["do" "clean," "deploy" "clojars"]}
+  :aliases {"test-cljs" ["shell" "bb" "test:cljs"]
+            "test-bb"   ["shell" "bb" "test:bb"]
+            "test-nbb"  ["shell" "bb" "test:nbb"]
+            "test"      ["do" "test," "test-cljs", "test-bb", "test-nbb"]
+            "cleantest" ["do" "clean," "test"]
+            "install"   ["do" "clean," "install"]
+            "deploy"    ["do" "clean," "deploy" "clojars"]}
 
   :source-paths ["src/clj" "src/cljc" "src/cljs"]
-   
+
   :profiles
   {:dev
    {:jvm-opts ["-XX:-TieredCompilation"]


### PR DESCRIPTION
Fixes CVE warning for snakeyaml 1.33 ([Critical Vulnerability](https://ossindex.sonatype.org/component/pkg:maven/org.yaml/snakeyaml@1.33))

See https://github.com/clj-commons/clj-yaml/issues/86 and https://github.com/clj-commons/clj-yaml/issues/134

---

```sh
chanakya@Chanakya-2 markdown-clj % lein test                                          

lein test markdown.md-file-test

lein test markdown.md-test

Ran 85 tests containing 155 assertions.
0 failures, 0 errors.

Testing markdown.md-test

Ran 76 tests containing 141 assertions.
0 failures, 0 errors.
```