### PR TITLE
remove reflection; fixes running in Native Image

### DIFF
--- a/src/clj/markdown/core.clj
+++ b/src/clj/markdown/core.clj
@@ -12,6 +12,8 @@
             StringWriter
             Writer]))
 
+(set! *warn-on-reflection* true)
+
 (defn- write [^Writer writer ^String text]
   (doseq [c text] (.write writer (int c))))
 
@@ -37,7 +39,7 @@
 
 (defn- reset-reader [rdr in]
   (if (instance? StringReader in)
-    (do (.reset in)
+    (do (.reset ^StringReader in)
         rdr)
     (io/reader in)))
 


### PR DESCRIPTION
This one little bit of reflection makes Native Image think that `reset` is a field rather than a method, so everything fails. :)