### PR TITLE
Support optional surrounding pipes for tables

### DIFF
--- a/src/cljc/markdown/tables.cljc
+++ b/src/cljc/markdown/tables.cljc
@@ -3,10 +3,13 @@
 
 (defn parse-table-row [text]
   (->> text
-       (#(if (= (first %) \|)
-          (apply str (rest %))
-          %))
        (string/trim)
+       (#(if (= (first %) \|)
+           (subs % 1)
+           %))
+       (#(if (and (seq %) (= (last %) \|))
+           (subs % 0 (dec (count %)))
+           %))
        (#(string/split % #"\|"))
        (map string/trim)
        (map #(identity {:text %}))))
@@ -71,40 +74,47 @@
             nil))
         divider-seq))
 
+(defn table-delimiter? [text]
+  (and (string/includes? text "|")
+       (let [cells (parse-table-row text)]
+         (and (seq cells)
+              (every? #(re-matches #":?-+:?" (:text %)) cells)))))
+
 (defn table [text state]
-  (let [table-row-re (re-find #"\|(?: [\S ]+ \|)+" text)
-        table-divider-re (re-find #"\|(?: ?:?-+:? ?\|)+" text)
-        is-table-row? (= table-row-re text)
+  (if (or (:code state) (:codeblock state))
+    [text state]
+    (let [is-table-row? (string/includes? text "|")
+          is-table-header?
+          (and is-table-row?
+               (not (get-in state [:table :in-table-body?]))
+               (table-delimiter? (or (:next-line state) "")))
+          is-table-divider?
+          (and (table-delimiter? text)
+               (get-in state [:table :in-table-body?])
+               (get-in state [:table :is-prev-header?]))]
+      (cond
         is-table-header?
-        (and is-table-row?
-             (not (get-in state [:table :in-table-body?])))
+        (let [header-seq (parse-table-row text)]
+          ["" (-> state
+                  (assoc-in [:table :is-prev-header?] true)
+                  (assoc-in [:table :in-table-body?] true)
+                  (update-in [:table :data] (fnil conj []) (vec header-seq)))])
+
         is-table-divider?
-        (and (= table-divider-re text)
-             (get-in state [:table :in-table-body?])
-             (get-in state [:table :is-prev-header?]))]
-    (cond
-      is-table-header?
-      (let [header-seq (parse-table-row text)]
-        ["" (-> state
-                (assoc-in [:table :is-prev-header?] true)
-                (assoc-in [:table :in-table-body?] true)
-                (update-in [:table :data] (fnil conj []) (vec header-seq)))])
+        (let [divider-seq (parse-table-row text)]
+          ["" (-> state
+                  (assoc-in [:table :is-prev-header?] false)
+                  (assoc-in [:table :alignment-seq]
+                            (divider-seq->alignment divider-seq)))])
 
-      is-table-divider?
-      (let [divider-seq (parse-table-row text)]
-        ["" (-> state
-                (assoc-in [:table :is-prev-header?] false)
-                (assoc-in [:table :alignment-seq]
-                          (divider-seq->alignment divider-seq)))])
+        (and is-table-row? (get-in state [:table :in-table-body?]))
+        (let [row-seq (parse-table-row text)]
+          ["" (-> state
+                  (assoc-in [:table :is-prev-header?] false)
+                  (update-in [:table :data] (fnil conj []) (vec row-seq)))])
 
-      is-table-row?
-      (let [row-seq (parse-table-row text)]
-        ["" (-> state
-                (assoc-in [:table :is-prev-header?] false)
-                (update-in [:table :data] (fnil conj []) (vec row-seq)))])
-
-      :else
-      (let [out (if (empty? (get-in state [:table :data]))
-                  text
-                  (str (table->str (:table state)) text))]
-        [out (dissoc state :table)]))))
+        :else
+        (let [out (if (empty? (get-in state [:table :data]))
+                    text
+                    (str (table->str (:table state)) text))]
+          [out (dissoc state :table)])))))

--- a/test/markdown/md_test.cljc
+++ b/test/markdown/md_test.cljc
@@ -455,7 +455,13 @@
 (deftest parse-table-row
   (is (= (tables/parse-table-row "| table cell contents |") [{:text "table cell contents"}]))
   (is (= (tables/parse-table-row "| contents 1 | contents 2 | contents 3 | contents 4 |")
-         [{:text "contents 1"} {:text "contents 2"} {:text "contents 3"} {:text "contents 4"}])))
+         [{:text "contents 1"} {:text "contents 2"} {:text "contents 3"} {:text "contents 4"}]))
+  (let [expected (tables/parse-table-row "| contents 1 | contents 2 |")]
+    (is (= expected (tables/parse-table-row "contents 1 | contents 2 |")))
+    (is (= expected (tables/parse-table-row "| contents 1 | contents 2")))
+    (is (= expected (tables/parse-table-row "contents 1 | contents 2"))))
+  (let [expected (tables/parse-table-row "| a | b |")]
+    (is (= expected (tables/parse-table-row "|a|b|")))))
 
 (deftest table-row->str
   (is (= (tables/table-row->str
@@ -492,6 +498,37 @@
   (is (= (tables/divider-seq->alignment
            [{:text "-----"} {:text ":-----"} {:text "-----:"} {:text ":-----:"}])
          [nil {:alignment :left} {:alignment :right} {:alignment :center}])))
+
+(deftest table-delimiter?
+  (is (tables/table-delimiter? "| --- | --- |"))
+  (is (tables/table-delimiter? ":-: | -----------:"))
+  (is (tables/table-delimiter? "|-|-|"))
+  (is (tables/table-delimiter? "|--|"))
+  (is (tables/table-delimiter? "| :--- | ---: | :---: |"))
+  (is (not (tables/table-delimiter? "| foo | bar |")))
+  (is (not (tables/table-delimiter? "| --- | oops |")))
+  (is (not (tables/table-delimiter? "no pipes here")))
+  (is (not (tables/table-delimiter? "||"))))
+
+(deftest table-optional-pipes
+  (is (= "<table><thead><tr><th style='text-align:center'>abc</th><th style='text-align:right'>defghi</th></tr></thead><tbody><tr><td style='text-align:center'>bar</td><td style='text-align:right'>baz</td></tr></tbody></table>"
+         (entry-function "| abc | defghi |\n:-: | -----------:\nbar | baz"))))
+
+(deftest table-delimiter-no-leading-pipe
+  (is (= "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+         (entry-function "| a | b |\n--- | ---\n| 1 | 2 |"))))
+
+(deftest table-body-no-trailing-pipe
+  (is (= "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>"
+         (entry-function "| a | b |\n| --- | --- |\n| 1 | 2\n| 3 | 4 |"))))
+
+(deftest table-zero-spaces
+  (is (= "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+         (entry-function "|a|b|\n|-|-|\n|1|2|"))))
+
+(deftest pipe-in-prose-not-a-table
+  (is (= "<p>A | B</p>" (entry-function "A | B")))
+  (is (= "<p>use foo | bar for baz</p>" (entry-function "use foo | bar for baz"))))
 
 (deftest n-dash
   (is (= "<p>boo &ndash; bar</p>" (entry-function "boo -- bar"))))


### PR DESCRIPTION
Fulfills support for "fenceless" tables that was omitted from #72. Text like this will now count as a table:

```markdown
First Header  | Second Header
------------- | -------------
Content Cell  | Content Cell
Content Cell  | Content Cell
```